### PR TITLE
Add initial version of JSON stream implementation

### DIFF
--- a/pkg/httpresponse/jsonstream.go
+++ b/pkg/httpresponse/jsonstream.go
@@ -1,6 +1,7 @@
 package httpresponse
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -18,14 +19,14 @@ import (
 
 // JSONStream implements a full-duplex newline-delimited JSON stream.
 //
-// Recv decodes one JSON value from the request body, and Send writes one JSON
-// value to the response body followed by a newline and an immediate flush.
+// Recv reads exactly one JSON value per line from the request body and Send
+// writes one JSON value to the response body followed by a newline and an
+// immediate flush.
 type JSONStream struct {
-	ctx       context.Context
 	req       *http.Request
-	dec       *json.Decoder
+	reader    *bufio.Reader
 	w         http.ResponseWriter
-	flusher   http.Flusher
+	recvMu    sync.Mutex
 	mu        sync.Mutex
 	closeOnce sync.Once
 	closed    atomic.Bool
@@ -47,25 +48,18 @@ func NewJSONStream(w http.ResponseWriter, r *http.Request, headers ...string) (*
 	if len(headers)%2 != 0 {
 		return nil, ErrBadRequest.With("headers must be key/value pairs")
 	}
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
+	if _, ok := w.(http.Flusher); !ok {
 		return nil, ErrInternalError.With("response writer does not support streaming")
 	}
 
-	body := r.Body
-	if body == nil {
-		body = http.NoBody
-	}
-
+	// Create the JSONStream
 	self := &JSONStream{
-		ctx:     r.Context(),
-		req:     r,
-		dec:     json.NewDecoder(body),
-		w:       w,
-		flusher: flusher,
+		req:    r,
+		reader: bufio.NewReader(r.Body),
+		w:      w,
 	}
 
+	// Set the headers on the response, and write out the header
 	w.Header().Set(types.ContentTypeHeader, types.ContentTypeJSONStream)
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -73,10 +67,10 @@ func NewJSONStream(w http.ResponseWriter, r *http.Request, headers ...string) (*
 	for i := 0; i < len(headers); i += 2 {
 		w.Header().Set(headers[i], headers[i+1])
 	}
-
 	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	w.(http.Flusher).Flush()
 
+	// Return success
 	return self, nil
 }
 
@@ -85,36 +79,55 @@ func NewJSONStream(w http.ResponseWriter, r *http.Request, headers ...string) (*
 
 // Context returns the request context associated with the stream.
 func (s *JSONStream) Context() context.Context {
-	if s == nil || s.ctx == nil {
-		return context.Background()
-	}
-	return s.ctx
+	return s.req.Context()
 }
 
-// Recv returns the next JSON frame from the request body.
+// Recv returns the next newline-delimited JSON frame from the request body.
+// A blank line is treated as a keep-alive heartbeat and returns nil, nil.
 func (s *JSONStream) Recv() (json.RawMessage, error) {
-	if s == nil || s.closed.Load() {
+	s.recvMu.Lock()
+	defer s.recvMu.Unlock()
+
+	// Return if already closed
+	if s.closed.Load() {
 		return nil, io.ErrClosedPipe
 	}
 
-	var frame json.RawMessage
-	if err := s.dec.Decode(&frame); err != nil {
-		return nil, err
+	// Read the next line from the request body
+	line, err := s.reader.ReadBytes('\n')
+	if err != nil {
+		if err != io.EOF || len(line) == 0 {
+			return nil, err
+		}
 	}
 
-	return frame, nil
+	// Treat a blank line as a keep-alive heartbeat.
+	frame := bytes.TrimSpace(line)
+	if len(frame) == 0 {
+		return nil, nil
+	}
+
+	// Decode the JSON frame to ensure it's valid JSON and compact it to remove whitespace.
+	var raw json.RawMessage
+	if err := json.Unmarshal(frame, &raw); err != nil {
+		return nil, ErrBadRequest.Withf("invalid json frame: %v", err)
+	}
+
+	// Return the compacted JSON frame
+	return raw, nil
 }
 
 // Send writes one JSON frame to the response body and flushes it immediately.
 func (s *JSONStream) Send(frame json.RawMessage) error {
-	if s == nil || s.closed.Load() {
+	if s.closed.Load() {
 		return io.ErrClosedPipe
 	}
 
-	data, err := compactJSONFrame(frame)
-	if err != nil {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, frame); err != nil {
 		return err
 	}
+	data := buf.Bytes()
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -128,40 +141,18 @@ func (s *JSONStream) Send(frame json.RawMessage) error {
 	if _, err := s.w.Write([]byte{'\n'}); err != nil {
 		return err
 	}
-	s.flusher.Flush()
+	s.w.(http.Flusher).Flush()
 
 	return nil
 }
 
 // Close closes the request body and marks the stream as closed.
 func (s *JSONStream) Close() error {
-	if s == nil {
-		return nil
-	}
-
 	s.closeOnce.Do(func() {
 		s.closed.Store(true)
 		if s.req != nil && s.req.Body != nil {
 			s.err = s.req.Body.Close()
 		}
 	})
-
 	return s.err
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// PRIVATE METHODS
-
-func compactJSONFrame(frame json.RawMessage) ([]byte, error) {
-	frame = bytes.TrimSpace(frame)
-	if len(frame) == 0 {
-		return nil, ErrBadRequest.With("json frame is empty")
-	}
-
-	var buf bytes.Buffer
-	if err := json.Compact(&buf, frame); err != nil {
-		return nil, ErrBadRequest.Withf("invalid json frame: %v", err)
-	}
-
-	return buf.Bytes(), nil
 }

--- a/pkg/httpresponse/jsonstream.go
+++ b/pkg/httpresponse/jsonstream.go
@@ -1,0 +1,167 @@
+package httpresponse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	// Packages
+	types "github.com/mutablelogic/go-server/pkg/types"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// JSONStream implements a full-duplex newline-delimited JSON stream.
+//
+// Recv decodes one JSON value from the request body, and Send writes one JSON
+// value to the response body followed by a newline and an immediate flush.
+type JSONStream struct {
+	ctx       context.Context
+	req       *http.Request
+	dec       *json.Decoder
+	w         http.ResponseWriter
+	flusher   http.Flusher
+	mu        sync.Mutex
+	closeOnce sync.Once
+	closed    atomic.Bool
+	err       error
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+// Create a new full-duplex JSON stream with mimetype application/ndjson.
+// Additional header tuples can be provided as a series of key-value pairs.
+func NewJSONStream(w http.ResponseWriter, r *http.Request, headers ...string) (*JSONStream, error) {
+	if w == nil {
+		return nil, ErrBadRequest.With("response writer is nil")
+	}
+	if r == nil {
+		return nil, ErrBadRequest.With("request is nil")
+	}
+	if len(headers)%2 != 0 {
+		return nil, ErrBadRequest.With("headers must be key/value pairs")
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, ErrInternalError.With("response writer does not support streaming")
+	}
+
+	body := r.Body
+	if body == nil {
+		body = http.NoBody
+	}
+
+	self := &JSONStream{
+		ctx:     r.Context(),
+		req:     r,
+		dec:     json.NewDecoder(body),
+		w:       w,
+		flusher: flusher,
+	}
+
+	w.Header().Set(types.ContentTypeHeader, types.ContentTypeJSONStream)
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	for i := 0; i < len(headers); i += 2 {
+		w.Header().Set(headers[i], headers[i+1])
+	}
+
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	return self, nil
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+// Context returns the request context associated with the stream.
+func (s *JSONStream) Context() context.Context {
+	if s == nil || s.ctx == nil {
+		return context.Background()
+	}
+	return s.ctx
+}
+
+// Recv returns the next JSON frame from the request body.
+func (s *JSONStream) Recv() (json.RawMessage, error) {
+	if s == nil || s.closed.Load() {
+		return nil, io.ErrClosedPipe
+	}
+
+	var frame json.RawMessage
+	if err := s.dec.Decode(&frame); err != nil {
+		return nil, err
+	}
+
+	return frame, nil
+}
+
+// Send writes one JSON frame to the response body and flushes it immediately.
+func (s *JSONStream) Send(frame json.RawMessage) error {
+	if s == nil || s.closed.Load() {
+		return io.ErrClosedPipe
+	}
+
+	data, err := compactJSONFrame(frame)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed.Load() {
+		return io.ErrClosedPipe
+	}
+	if _, err := s.w.Write(data); err != nil {
+		return err
+	}
+	if _, err := s.w.Write([]byte{'\n'}); err != nil {
+		return err
+	}
+	s.flusher.Flush()
+
+	return nil
+}
+
+// Close closes the request body and marks the stream as closed.
+func (s *JSONStream) Close() error {
+	if s == nil {
+		return nil
+	}
+
+	s.closeOnce.Do(func() {
+		s.closed.Store(true)
+		if s.req != nil && s.req.Body != nil {
+			s.err = s.req.Body.Close()
+		}
+	})
+
+	return s.err
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PRIVATE METHODS
+
+func compactJSONFrame(frame json.RawMessage) ([]byte, error) {
+	frame = bytes.TrimSpace(frame)
+	if len(frame) == 0 {
+		return nil, ErrBadRequest.With("json frame is empty")
+	}
+
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, frame); err != nil {
+		return nil, ErrBadRequest.Withf("invalid json frame: %v", err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/httpresponse/jsonstream_test.go
+++ b/pkg/httpresponse/jsonstream_test.go
@@ -90,6 +90,56 @@ func Test_jsonstream_recv(t *testing.T) {
 	assert.ErrorIs(err, io.EOF)
 }
 
+func Test_jsonstream_recv_blank_line_is_keepalive(t *testing.T) {
+	assert := assert.New(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{\"a\":1}\n\n{\"b\":2}\n"))
+	resp := httptest.NewRecorder()
+
+	stream, err := httpresponse.NewJSONStream(resp, req)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	frame, err := stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(json.RawMessage(`{"a":1}`), frame)
+
+	frame, err = stream.Recv()
+	assert.Nil(frame)
+	assert.NoError(err)
+
+	frame, err = stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(json.RawMessage(`{"b":2}`), frame)
+}
+
+func Test_jsonstream_recv_trailing_blank_line_is_keepalive(t *testing.T) {
+	assert := assert.New(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{\"a\":1}\n\n"))
+	resp := httptest.NewRecorder()
+
+	stream, err := httpresponse.NewJSONStream(resp, req)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	frame, err := stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(json.RawMessage(`{"a":1}`), frame)
+
+	frame, err = stream.Recv()
+	assert.Nil(frame)
+	assert.NoError(err)
+
+	frame, err = stream.Recv()
+	assert.Nil(frame)
+	assert.ErrorIs(err, io.EOF)
+
+	frame, err = stream.Recv()
+	assert.Nil(frame)
+	assert.ErrorIs(err, io.EOF)
+}
+
 func Test_jsonstream_send(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/httpresponse/jsonstream_test.go
+++ b/pkg/httpresponse/jsonstream_test.go
@@ -1,0 +1,149 @@
+package httpresponse_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	// Packages
+	"github.com/mutablelogic/go-server/pkg/httpresponse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type trackedReadCloser struct {
+	reader io.Reader
+	closed int
+}
+
+func (t *trackedReadCloser) Read(p []byte) (int, error) {
+	return t.reader.Read(p)
+}
+
+func (t *trackedReadCloser) Close() error {
+	t.closed++
+	return nil
+}
+
+func Test_jsonstream_new(t *testing.T) {
+	assert := assert.New(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	resp := httptest.NewRecorder()
+
+	stream, err := httpresponse.NewJSONStream(resp, req, "X-Test", "ok")
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+
+	assert.Equal(http.StatusOK, resp.Code)
+	assert.Equal("application/ndjson", resp.Header().Get("Content-Type"))
+	assert.Equal("no-cache", resp.Header().Get("Cache-Control"))
+	assert.Equal("keep-alive", resp.Header().Get("Connection"))
+	assert.Equal("no", resp.Header().Get("X-Accel-Buffering"))
+	assert.Equal("ok", resp.Header().Get("X-Test"))
+	assert.NotNil(stream.Context())
+	assert.NoError(stream.Close())
+}
+
+func Test_jsonstream_new_errors(t *testing.T) {
+	assert := assert.New(t)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	stream, err := httpresponse.NewJSONStream(nil, req)
+	assert.Nil(stream)
+	assert.Error(err)
+
+	stream, err = httpresponse.NewJSONStream(resp, nil)
+	assert.Nil(stream)
+	assert.Error(err)
+
+	stream, err = httpresponse.NewJSONStream(resp, req, "X-Test")
+	assert.Nil(stream)
+	assert.Error(err)
+}
+
+func Test_jsonstream_recv(t *testing.T) {
+	assert := assert.New(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{\"a\":1}\n{\"b\":2}\n"))
+	resp := httptest.NewRecorder()
+
+	stream, err := httpresponse.NewJSONStream(resp, req)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	frame, err := stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(json.RawMessage(`{"a":1}`), frame)
+
+	frame, err = stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(json.RawMessage(`{"b":2}`), frame)
+
+	frame, err = stream.Recv()
+	assert.Nil(frame)
+	assert.ErrorIs(err, io.EOF)
+}
+
+func Test_jsonstream_send(t *testing.T) {
+	assert := assert.New(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	resp := httptest.NewRecorder()
+
+	stream, err := httpresponse.NewJSONStream(resp, req)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	err = stream.Send(json.RawMessage(" { \"a\": 1, \"b\": [ 1, 2 ] } "))
+	require.NoError(t, err)
+	err = stream.Send(json.RawMessage("\n{\n  \"ok\": true\n}\n"))
+	require.NoError(t, err)
+
+	assert.Equal("{\"a\":1,\"b\":[1,2]}\n{\"ok\":true}\n", resp.Body.String())
+	assert.Equal("application/ndjson", resp.Header().Get("Content-Type"))
+}
+
+func Test_jsonstream_send_errors(t *testing.T) {
+	assert := assert.New(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	resp := httptest.NewRecorder()
+
+	stream, err := httpresponse.NewJSONStream(resp, req)
+	require.NoError(t, err)
+
+	assert.Error(stream.Send(nil))
+	assert.Error(stream.Send(json.RawMessage("not-json")))
+
+	require.NoError(t, stream.Close())
+	assert.ErrorIs(stream.Send(json.RawMessage(`{"ok":true}`)), io.ErrClosedPipe)
+	frame, err := stream.Recv()
+	assert.Nil(frame)
+	assert.ErrorIs(err, io.ErrClosedPipe)
+}
+
+func Test_jsonstream_close(t *testing.T) {
+	assert := assert.New(t)
+
+	body := &trackedReadCloser{reader: strings.NewReader(`{"a":1}`)}
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	req.Body = body
+	resp := httptest.NewRecorder()
+
+	stream, err := httpresponse.NewJSONStream(resp, req)
+	require.NoError(t, err)
+
+	assert.NoError(stream.Close())
+	assert.NoError(stream.Close())
+	assert.Equal(1, body.closed)
+	assert.ErrorIs(stream.Send(json.RawMessage(`{"ok":true}`)), io.ErrClosedPipe)
+	frame, err := stream.Recv()
+	assert.Nil(frame)
+	assert.ErrorIs(err, io.ErrClosedPipe)
+}


### PR DESCRIPTION
This pull request introduces a new `JSONStream` type to the `httpresponse` package, providing a full-duplex, newline-delimited JSON streaming interface for HTTP. It also adds comprehensive tests to validate the correct behavior and error handling of the new stream implementation.

**New JSON streaming functionality:**

* Added the `JSONStream` type in `jsonstream.go` to support full-duplex newline-delimited JSON streaming over HTTP, including methods for sending, receiving, and closing the stream.
* Implemented the `NewJSONStream` constructor to initialize the stream, set appropriate headers (e.g., `Content-Type: application/ndjson`), and ensure immediate flushing.
* Added error handling for invalid usage, such as nil inputs or unsupported writers, and for malformed or empty JSON frames.

**Testing and validation:**

* Added `jsonstream_test.go` with tests covering stream creation, header verification, sending and receiving frames, error cases, and proper resource cleanup on close.