### PR TITLE
Enhance server streaming and update header parsing

### DIFF
--- a/pkg/httpresponse/error.go
+++ b/pkg/httpresponse/error.go
@@ -18,6 +18,7 @@ type Err int
 // ErrResponse is the JSON error body returned by all error responses.
 // It is also used to generate the OpenAPI response schema.
 type ErrResponse struct {
+	Type   string `json:"object"           jsonschema:"The type of the response, always 'error'"`
 	Code   int    `json:"code"             jsonschema:"HTTP status code"`
 	Reason string `json:"reason,omitempty" jsonschema:"Human-readable reason phrase"`
 	Detail any    `json:"detail,omitempty" jsonschema:"Optional additional detail"`
@@ -45,6 +46,7 @@ const (
 func Error(w http.ResponseWriter, err error, detail ...any) error {
 	// Create a JSON object for the error response
 	e := ErrResponse{
+		Type:   "error",
 		Code:   http.StatusInternalServerError,
 		Reason: err.Error(),
 	}

--- a/pkg/httpresponse/error_test.go
+++ b/pkg/httpresponse/error_test.go
@@ -36,6 +36,7 @@ func Test_Error_003(t *testing.T) {
 	assert.Equal(http.StatusOK, recorder.Code)
 
 	expected := ErrResponse{
+		Type:   "error",
 		Code:   http.StatusOK,
 		Reason: http.StatusText(http.StatusOK),
 		Detail: "detail",
@@ -55,6 +56,7 @@ func Test_Error_004(t *testing.T) {
 	assert.Equal(http.StatusOK, recorder.Code)
 
 	expected := ErrResponse{
+		Type:   "error",
 		Code:   http.StatusOK,
 		Reason: http.StatusText(http.StatusOK),
 		Detail: []any{"detail", "detail"},

--- a/pkg/httpresponse/jsonstream.go
+++ b/pkg/httpresponse/jsonstream.go
@@ -33,6 +33,8 @@ type JSONStream struct {
 	err       error
 }
 
+type JSONStreamHandlerFunc func(r <-chan json.RawMessage, w chan<- json.RawMessage) error
+
 ///////////////////////////////////////////////////////////////////////////////
 // LIFECYCLE
 
@@ -50,6 +52,9 @@ func NewJSONStream(w http.ResponseWriter, r *http.Request, headers ...string) (*
 	}
 	if _, ok := w.(http.Flusher); !ok {
 		return nil, ErrInternalError.With("response writer does not support streaming")
+	}
+	if rc := http.NewResponseController(w); rc != nil {
+		_ = rc.EnableFullDuplex()
 	}
 
 	// Create the JSONStream
@@ -119,31 +124,82 @@ func (s *JSONStream) Recv() (json.RawMessage, error) {
 
 // Send writes one JSON frame to the response body and flushes it immediately.
 func (s *JSONStream) Send(frame json.RawMessage) error {
-	if s.closed.Load() {
-		return io.ErrClosedPipe
+	if frame == nil {
+		return ErrBadRequest.With("invalid json frame: nil")
 	}
+	return s.sendFrame(frame)
+}
 
-	var buf bytes.Buffer
-	if err := json.Compact(&buf, frame); err != nil {
-		return err
-	}
-	data := buf.Bytes()
+// NewJSONStreamHandler wraps a channel-based handler function in an HTTP handler.
+// The receive channel yields compacted JSON frames from the request body and nil
+// for heartbeat lines. Sending nil on the write channel emits a blank heartbeat line.
+func NewJSONStreamHandler(fn JSONStreamHandlerFunc, headers ...string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fn == nil {
+			_ = Error(w, ErrInternalError.With("json stream handler is nil"))
+			return
+		}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+		stream, err := NewJSONStream(w, r, headers...)
+		if err != nil {
+			_ = Error(w, err)
+			return
+		}
+		defer stream.Close()
 
-	if s.closed.Load() {
-		return io.ErrClosedPipe
-	}
-	if _, err := s.w.Write(data); err != nil {
-		return err
-	}
-	if _, err := s.w.Write([]byte{'\n'}); err != nil {
-		return err
-	}
-	s.w.(http.Flusher).Flush()
+		recvCh := make(chan json.RawMessage)
+		sendCh := make(chan json.RawMessage)
 
-	return nil
+		var wg sync.WaitGroup
+		var recvErr error
+		var sendErr error
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer close(recvCh)
+
+			for {
+				frame, err := stream.Recv()
+				if err == io.EOF {
+					return
+				}
+				if err != nil {
+					recvErr = err
+					return
+				}
+
+				select {
+				case <-stream.Context().Done():
+					return
+				case recvCh <- frame:
+				}
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			var failed bool
+			for frame := range sendCh {
+				if failed {
+					continue
+				}
+				if err := stream.sendFrame(frame); err != nil {
+					sendErr = err
+					failed = true
+				}
+			}
+		}()
+
+		_ = fn(recvCh, sendCh)
+		close(sendCh)
+		wg.Wait()
+
+		_ = recvErr
+		_ = sendErr
+	})
 }
 
 // Close closes the request body and marks the stream as closed.
@@ -155,4 +211,34 @@ func (s *JSONStream) Close() error {
 		}
 	})
 	return s.err
+}
+
+func (s *JSONStream) sendFrame(frame json.RawMessage) error {
+	if s.closed.Load() {
+		return io.ErrClosedPipe
+	}
+
+	var data []byte
+	if frame == nil {
+		data = []byte{'\n'}
+	} else {
+		var buf bytes.Buffer
+		if err := json.Compact(&buf, frame); err != nil {
+			return err
+		}
+		data = append(buf.Bytes(), '\n')
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed.Load() {
+		return io.ErrClosedPipe
+	}
+	if _, err := s.w.Write(data); err != nil {
+		return err
+	}
+	s.w.(http.Flusher).Flush()
+
+	return nil
 }

--- a/pkg/httpresponse/jsonstream.go
+++ b/pkg/httpresponse/jsonstream.go
@@ -17,30 +17,43 @@ import (
 ///////////////////////////////////////////////////////////////////////////////
 // TYPES
 
-// JSONStream implements a full-duplex newline-delimited JSON stream.
-//
-// Recv reads exactly one JSON value per line from the request body and Send
-// writes one JSON value to the response body followed by a newline and an
-// immediate flush.
-type JSONStream struct {
+// JSONStream mirrors the client-side streaming interface: Recv yields newline-
+// delimited JSON frames from the request body, and Send writes one JSON frame
+// to the response body followed by a newline and an immediate flush.
+type JSONStream interface {
+	Recv() <-chan json.RawMessage
+	Send(json.RawMessage) error
+}
+
+// JSONStreamConn is the richer stream connection returned by NewJSONStream.
+// It adds access to the request context and explicit close semantics.
+type JSONStreamConn interface {
+	JSONStream
+	Context() context.Context
+	Close() error
+}
+
+type jsonstream struct {
 	req       *http.Request
 	reader    *bufio.Reader
 	w         http.ResponseWriter
 	recvMu    sync.Mutex
 	mu        sync.Mutex
+	recvOnce  sync.Once
+	recvCh    chan json.RawMessage
 	closeOnce sync.Once
 	closed    atomic.Bool
 	err       error
 }
 
-type JSONStreamHandlerFunc func(r <-chan json.RawMessage, w chan<- json.RawMessage) error
+type JSONStreamHandlerFunc func(req *http.Request, stream JSONStream) error
 
 ///////////////////////////////////////////////////////////////////////////////
 // LIFECYCLE
 
 // Create a new full-duplex JSON stream with mimetype application/ndjson.
 // Additional header tuples can be provided as a series of key-value pairs.
-func NewJSONStream(w http.ResponseWriter, r *http.Request, headers ...string) (*JSONStream, error) {
+func NewJSONStream(w http.ResponseWriter, r *http.Request, headers ...string) (JSONStreamConn, error) {
 	if w == nil {
 		return nil, ErrBadRequest.With("response writer is nil")
 	}
@@ -58,10 +71,11 @@ func NewJSONStream(w http.ResponseWriter, r *http.Request, headers ...string) (*
 	}
 
 	// Create the JSONStream
-	self := &JSONStream{
+	self := &jsonstream{
 		req:    r,
 		reader: bufio.NewReader(r.Body),
 		w:      w,
+		recvCh: make(chan json.RawMessage),
 	}
 
 	// Set the headers on the response, and write out the header
@@ -83,50 +97,75 @@ func NewJSONStream(w http.ResponseWriter, r *http.Request, headers ...string) (*
 // PUBLIC METHODS
 
 // Context returns the request context associated with the stream.
-func (s *JSONStream) Context() context.Context {
+func (s *jsonstream) Context() context.Context {
 	return s.req.Context()
 }
 
-// Recv returns the next newline-delimited JSON frame from the request body.
-// A blank line is treated as a keep-alive heartbeat and returns nil, nil.
-func (s *JSONStream) Recv() (json.RawMessage, error) {
+// Recv returns a channel of newline-delimited JSON frames from the request body.
+// Blank lines are treated as keep-alive heartbeats and emitted as nil frames.
+func (s *jsonstream) Recv() <-chan json.RawMessage {
+	s.recvOnce.Do(func() {
+		if s.closed.Load() {
+			close(s.recvCh)
+			return
+		}
+		go s.recvLoop()
+	})
+	return s.recvCh
+}
+
+func (s *jsonstream) recvLoop() {
+	defer close(s.recvCh)
+
+	for {
+		frame, ok := s.recvFrame()
+		if !ok {
+			return
+		}
+
+		select {
+		case <-s.Context().Done():
+			return
+		case s.recvCh <- frame:
+		}
+	}
+}
+
+func (s *jsonstream) recvFrame() (json.RawMessage, bool) {
 	s.recvMu.Lock()
 	defer s.recvMu.Unlock()
 
 	// Return if already closed
 	if s.closed.Load() {
-		return nil, io.ErrClosedPipe
+		return nil, false
 	}
 
 	// Read the next line from the request body
 	line, err := s.reader.ReadBytes('\n')
 	if err != nil {
 		if err != io.EOF || len(line) == 0 {
-			return nil, err
+			return nil, false
 		}
 	}
 
 	// Treat a blank line as a keep-alive heartbeat.
 	frame := bytes.TrimSpace(line)
 	if len(frame) == 0 {
-		return nil, nil
+		return nil, true
 	}
 
 	// Decode the JSON frame to ensure it's valid JSON and compact it to remove whitespace.
 	var raw json.RawMessage
 	if err := json.Unmarshal(frame, &raw); err != nil {
-		return nil, ErrBadRequest.Withf("invalid json frame: %v", err)
+		return nil, false
 	}
 
 	// Return the compacted JSON frame
-	return raw, nil
+	return raw, true
 }
 
 // Send writes one JSON frame to the response body and flushes it immediately.
-func (s *JSONStream) Send(frame json.RawMessage) error {
-	if frame == nil {
-		return ErrBadRequest.With("invalid json frame: nil")
-	}
+func (s *jsonstream) Send(frame json.RawMessage) error {
 	return s.sendFrame(frame)
 }
 
@@ -147,63 +186,12 @@ func NewJSONStreamHandler(fn JSONStreamHandlerFunc, headers ...string) http.Hand
 		}
 		defer stream.Close()
 
-		recvCh := make(chan json.RawMessage)
-		sendCh := make(chan json.RawMessage)
-
-		var wg sync.WaitGroup
-		var recvErr error
-		var sendErr error
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer close(recvCh)
-
-			for {
-				frame, err := stream.Recv()
-				if err == io.EOF {
-					return
-				}
-				if err != nil {
-					recvErr = err
-					return
-				}
-
-				select {
-				case <-stream.Context().Done():
-					return
-				case recvCh <- frame:
-				}
-			}
-		}()
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			var failed bool
-			for frame := range sendCh {
-				if failed {
-					continue
-				}
-				if err := stream.sendFrame(frame); err != nil {
-					sendErr = err
-					failed = true
-				}
-			}
-		}()
-
-		_ = fn(recvCh, sendCh)
-		close(sendCh)
-		wg.Wait()
-
-		_ = recvErr
-		_ = sendErr
+		_ = fn(r, stream)
 	})
 }
 
 // Close closes the request body and marks the stream as closed.
-func (s *JSONStream) Close() error {
+func (s *jsonstream) Close() error {
 	s.closeOnce.Do(func() {
 		s.closed.Store(true)
 		if s.req != nil && s.req.Body != nil {
@@ -213,7 +201,7 @@ func (s *JSONStream) Close() error {
 	return s.err
 }
 
-func (s *JSONStream) sendFrame(frame json.RawMessage) error {
+func (s *jsonstream) sendFrame(frame json.RawMessage) error {
 	if s.closed.Load() {
 		return io.ErrClosedPipe
 	}

--- a/pkg/httpresponse/jsonstream_test.go
+++ b/pkg/httpresponse/jsonstream_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func recvFrame(t *testing.T, stream httpresponse.JSONStream) (json.RawMessage, bool) {
+	t.Helper()
+	ch := stream.Recv()
+	require.NotNil(t, ch)
+	frame, ok := <-ch
+	return frame, ok
+}
+
 type trackedReadCloser struct {
 	reader io.Reader
 	closed int
@@ -77,17 +85,17 @@ func Test_jsonstream_recv(t *testing.T) {
 	require.NoError(t, err)
 	defer stream.Close()
 
-	frame, err := stream.Recv()
-	require.NoError(t, err)
+	frame, ok := recvFrame(t, stream)
+	require.True(t, ok)
 	assert.Equal(json.RawMessage(`{"a":1}`), frame)
 
-	frame, err = stream.Recv()
-	require.NoError(t, err)
+	frame, ok = recvFrame(t, stream)
+	require.True(t, ok)
 	assert.Equal(json.RawMessage(`{"b":2}`), frame)
 
-	frame, err = stream.Recv()
+	frame, ok = recvFrame(t, stream)
 	assert.Nil(frame)
-	assert.ErrorIs(err, io.EOF)
+	assert.False(ok)
 }
 
 func Test_jsonstream_recv_blank_line_is_keepalive(t *testing.T) {
@@ -100,16 +108,16 @@ func Test_jsonstream_recv_blank_line_is_keepalive(t *testing.T) {
 	require.NoError(t, err)
 	defer stream.Close()
 
-	frame, err := stream.Recv()
-	require.NoError(t, err)
+	frame, ok := recvFrame(t, stream)
+	require.True(t, ok)
 	assert.Equal(json.RawMessage(`{"a":1}`), frame)
 
-	frame, err = stream.Recv()
+	frame, ok = recvFrame(t, stream)
 	assert.Nil(frame)
-	assert.NoError(err)
+	assert.True(ok)
 
-	frame, err = stream.Recv()
-	require.NoError(t, err)
+	frame, ok = recvFrame(t, stream)
+	require.True(t, ok)
 	assert.Equal(json.RawMessage(`{"b":2}`), frame)
 }
 
@@ -123,21 +131,21 @@ func Test_jsonstream_recv_trailing_blank_line_is_keepalive(t *testing.T) {
 	require.NoError(t, err)
 	defer stream.Close()
 
-	frame, err := stream.Recv()
-	require.NoError(t, err)
+	frame, ok := recvFrame(t, stream)
+	require.True(t, ok)
 	assert.Equal(json.RawMessage(`{"a":1}`), frame)
 
-	frame, err = stream.Recv()
+	frame, ok = recvFrame(t, stream)
 	assert.Nil(frame)
-	assert.NoError(err)
+	assert.True(ok)
 
-	frame, err = stream.Recv()
+	frame, ok = recvFrame(t, stream)
 	assert.Nil(frame)
-	assert.ErrorIs(err, io.EOF)
+	assert.False(ok)
 
-	frame, err = stream.Recv()
+	frame, ok = recvFrame(t, stream)
 	assert.Nil(frame)
-	assert.ErrorIs(err, io.EOF)
+	assert.False(ok)
 }
 
 func Test_jsonstream_send(t *testing.T) {
@@ -168,14 +176,14 @@ func Test_jsonstream_send_errors(t *testing.T) {
 	stream, err := httpresponse.NewJSONStream(resp, req)
 	require.NoError(t, err)
 
-	assert.Error(stream.Send(nil))
+	assert.NoError(stream.Send(nil))
 	assert.Error(stream.Send(json.RawMessage("not-json")))
 
 	require.NoError(t, stream.Close())
 	assert.ErrorIs(stream.Send(json.RawMessage(`{"ok":true}`)), io.ErrClosedPipe)
-	frame, err := stream.Recv()
+	frame, ok := recvFrame(t, stream)
 	assert.Nil(frame)
-	assert.ErrorIs(err, io.ErrClosedPipe)
+	assert.False(ok)
 }
 
 func Test_jsonstream_close(t *testing.T) {
@@ -193,18 +201,21 @@ func Test_jsonstream_close(t *testing.T) {
 	assert.NoError(stream.Close())
 	assert.Equal(1, body.closed)
 	assert.ErrorIs(stream.Send(json.RawMessage(`{"ok":true}`)), io.ErrClosedPipe)
-	frame, err := stream.Recv()
+	frame, ok := recvFrame(t, stream)
 	assert.Nil(frame)
-	assert.ErrorIs(err, io.ErrClosedPipe)
+	assert.False(ok)
 }
 
 func Test_jsonstream_handler_echo(t *testing.T) {
-	srv := httptest.NewServer(httpresponse.NewJSONStreamHandler(func(r <-chan json.RawMessage, w chan<- json.RawMessage) error {
-		for req := range r {
-			if req == nil {
+	srv := httptest.NewServer(httpresponse.NewJSONStreamHandler(func(req *http.Request, stream httpresponse.JSONStream) error {
+		assert.Equal(t, http.MethodPost, req.Method)
+		for frame := range stream.Recv() {
+			if frame == nil {
 				continue
 			}
-			w <- req
+			if err := stream.Send(frame); err != nil {
+				return err
+			}
 		}
 		return nil
 	}, "X-Test", "ok"))
@@ -229,9 +240,12 @@ func Test_jsonstream_handler_echo(t *testing.T) {
 }
 
 func Test_jsonstream_handler_heartbeat_forwarding(t *testing.T) {
-	srv := httptest.NewServer(httpresponse.NewJSONStreamHandler(func(r <-chan json.RawMessage, w chan<- json.RawMessage) error {
-		for req := range r {
-			w <- req
+	srv := httptest.NewServer(httpresponse.NewJSONStreamHandler(func(req *http.Request, stream httpresponse.JSONStream) error {
+		assert.Equal(t, "/", req.URL.Path)
+		for frame := range stream.Recv() {
+			if err := stream.Send(frame); err != nil {
+				return err
+			}
 		}
 		return nil
 	}))

--- a/pkg/httpresponse/jsonstream_test.go
+++ b/pkg/httpresponse/jsonstream_test.go
@@ -197,3 +197,75 @@ func Test_jsonstream_close(t *testing.T) {
 	assert.Nil(frame)
 	assert.ErrorIs(err, io.ErrClosedPipe)
 }
+
+func Test_jsonstream_handler_echo(t *testing.T) {
+	srv := httptest.NewServer(httpresponse.NewJSONStreamHandler(func(r <-chan json.RawMessage, w chan<- json.RawMessage) error {
+		for req := range r {
+			if req == nil {
+				continue
+			}
+			w <- req
+		}
+		return nil
+	}, "X-Test", "ok"))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader("{\"a\":1}\n{\"b\":2}\n"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/ndjson")
+	req.Header.Set("Accept", "application/ndjson")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/ndjson", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "ok", resp.Header.Get("X-Test"))
+	assert.Equal(t, "{\"a\":1}\n{\"b\":2}\n", string(data))
+}
+
+func Test_jsonstream_handler_heartbeat_forwarding(t *testing.T) {
+	srv := httptest.NewServer(httpresponse.NewJSONStreamHandler(func(r <-chan json.RawMessage, w chan<- json.RawMessage) error {
+		for req := range r {
+			w <- req
+		}
+		return nil
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader("\n{\"ok\":true}\n"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/ndjson")
+	req.Header.Set("Accept", "application/ndjson")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "\n{\"ok\":true}\n", string(data))
+}
+
+func Test_jsonstream_handler_nil(t *testing.T) {
+	srv := httptest.NewServer(httpresponse.NewJSONStreamHandler(nil))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Contains(t, string(data), "json stream handler is nil")
+}

--- a/pkg/otel/middleware_test.go
+++ b/pkg/otel/middleware_test.go
@@ -8,11 +8,13 @@ import (
 	"testing"
 
 	// Packages
+	httpresponse "github.com/mutablelogic/go-server/pkg/httpresponse"
 	otel "github.com/mutablelogic/go-server/pkg/otel"
 	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
 	gootel "go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	tracetest "go.opentelemetry.io/otel/sdk/trace/tracetest"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
 
@@ -141,4 +143,18 @@ func TestHTTPHandler_ServerError(t *testing.T) {
 	assert.Equal(http.StatusInternalServerError, rec.Code)
 	spans := exporter.GetSpans()
 	assert.Len(spans, 1)
+}
+
+func TestWrappedResponseWriterSupportsJSONStream(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/stream", http.NoBody)
+	rec := httptest.NewRecorder()
+	wrapped := otel.NewResponseWriter(rec)
+
+	stream, err := httpresponse.NewJSONStream(wrapped, req)
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+	t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/ndjson", rec.Header().Get("Content-Type"))
 }

--- a/pkg/otel/responsewriter.go
+++ b/pkg/otel/responsewriter.go
@@ -99,6 +99,14 @@ func (rw *responseWriter) ReadFrom(r io.Reader) (int64, error) {
 	return n, err
 }
 
+// Flush preserves streaming semantics when middleware wraps a response writer
+// that already supports flushing.
+func (rw *responseWriter) Flush() {
+	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 // Satisfy http.ResponseController support (Go 1.20+)
 func (rw *responseWriter) Unwrap() http.ResponseWriter {
 	return rw.ResponseWriter

--- a/pkg/types/http.go
+++ b/pkg/types/http.go
@@ -10,8 +10,8 @@ import (
 const (
 	SchemeSecure             = "https"
 	SchemeInsecure           = "http"
-	ContentTypeHeader        = "Content-Type"
 	ContentAcceptHeader      = "Accept"
+	ContentTypeHeader        = "Content-Type"
 	ContentLengthHeader      = "Content-Length"
 	ContentDispositonHeader  = "Content-Disposition"
 	ContentModifiedHeader    = "Last-Modified"
@@ -29,5 +29,9 @@ func RequestContentType(r *http.Request) (string, error) {
 }
 
 func AcceptContentType(r *http.Request) (string, error) {
-	return ParseContentType(r.Header.Get(ContentAcceptHeader))
+	if accept := r.Header.Get(ContentAcceptHeader); accept == "" {
+		return "", nil
+	} else {
+		return ParseContentType(accept)
+	}
 }

--- a/pkg/types/http_test.go
+++ b/pkg/types/http_test.go
@@ -29,8 +29,9 @@ func Test_RequestContentType(t *testing.T) {
 
 	t.Run("Empty content type", func(t *testing.T) {
 		r, _ := http.NewRequest(http.MethodGet, "/", nil)
-		_, err := types.RequestContentType(r)
-		assert.Error(err)
+		mimetype, err := types.RequestContentType(r)
+		assert.NoError(err)
+		assert.Equal("application/octet-stream", mimetype)
 	})
 
 	t.Run("Multipart form data", func(t *testing.T) {
@@ -63,7 +64,8 @@ func Test_AcceptContentType(t *testing.T) {
 
 	t.Run("Empty accept", func(t *testing.T) {
 		r, _ := http.NewRequest(http.MethodGet, "/", nil)
-		_, err := types.AcceptContentType(r)
-		assert.Error(err)
+		mimetype, err := types.AcceptContentType(r)
+		assert.NoError(err)
+		assert.Equal("", mimetype)
 	})
 }

--- a/pkg/types/mime.go
+++ b/pkg/types/mime.go
@@ -9,20 +9,21 @@ import (
 // GLOBALS
 
 const (
-	ContentTypeJSON       = "application/json"
-	ContentTypeJSONStream = "application/ndjson"
-	ContentTypeYAML       = "application/yaml"
-	ContentTypeXML        = "application/xml"
-	ContentTypeRSS        = "application/rss+xml"
-	ContentTypeBinary     = "application/octet-stream"
-	ContentTypeCSV        = "text/csv"
-	ContentTypeTextXml    = "text/xml"
-	ContentTypeTextPlain  = "text/plain"
-	ContentTypeTextStream = "text/event-stream"
-	ContentTypeForm       = "application/x-www-form-urlencoded"
-	ContentTypeFormData   = "multipart/form-data"
-	ContentTypeHTML       = "text/html"
-	ContentTypeAny        = "*/*"
+	ContentTypeJSON             = "application/json"
+	ContentTypeJSONStream       = "application/ndjson"
+	ContentTypeJSONStreamLegacy = "application/x-ndjson"
+	ContentTypeYAML             = "application/yaml"
+	ContentTypeXML              = "application/xml"
+	ContentTypeRSS              = "application/rss+xml"
+	ContentTypeBinary           = "application/octet-stream"
+	ContentTypeCSV              = "text/csv"
+	ContentTypeTextXml          = "text/xml"
+	ContentTypeTextPlain        = "text/plain"
+	ContentTypeTextStream       = "text/event-stream"
+	ContentTypeForm             = "application/x-www-form-urlencoded"
+	ContentTypeFormData         = "multipart/form-data"
+	ContentTypeHTML             = "text/html"
+	ContentTypeAny              = "*/*"
 )
 
 // reHeaderKey matches a valid RFC 7230 header field name token:
@@ -32,10 +33,17 @@ var reHeaderKey = regexp.MustCompile(`^[!#$%&'*+\-.^_` + "`" + `|~0-9A-Za-z]+$`)
 ///////////////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS
 
-// Parse a content type header to return the mimetype
+// Parse a content type header to return the mimetype, return binary
+// if the header is invalid or empty
 func ParseContentType(header string) (string, error) {
-	mimetype, _, err := mime.ParseMediaType(header)
-	return mimetype, err
+	if header == "" {
+		return ContentTypeBinary, nil
+	}
+	if mimetype, _, err := mime.ParseMediaType(header); err != nil {
+		return ContentTypeBinary, err
+	} else {
+		return mimetype, nil
+	}
 }
 
 // IsValidHeaderKey reports whether s is a valid RFC 7230 header field name

--- a/pkg/types/mime_test.go
+++ b/pkg/types/mime_test.go
@@ -12,10 +12,9 @@ func Test_Mime_001(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("1", func(t *testing.T) {
-		_, err := types.ParseContentType("")
-		if assert.Error(err) {
-			assert.ErrorContains(err, "no media type")
-		}
+		mimetype, err := types.ParseContentType("")
+		assert.NoError(err)
+		assert.Equal(types.ContentTypeBinary, mimetype)
 	})
 
 	t.Run("2", func(t *testing.T) {


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the HTTP response and streaming infrastructure, with a particular focus on the JSON stream API, error response consistency, and content type handling. The main highlights are a new channel-based `JSONStream` interface, improved error response structure, more robust content type parsing, and enhanced test coverage.

**JSON Streaming API Overhaul:**

* Refactored `JSONStream` to be an interface with channel-based receiving (`Recv() <-chan json.RawMessage`) and sending, replacing the previous method-based approach. Introduced `JSONStreamConn` for richer stream management and added `NewJSONStreamHandler` for easy HTTP handler integration. Heartbeat (blank line) handling is now explicit and consistent. (`pkg/httpresponse/jsonstream.go`, `pkg/httpresponse/jsonstream_test.go`) [[1]](diffhunk://#diff-12a9a4b1453cab2346305cc155ee8710587036918ae5bcb98c912f93361d3262L20-R56) [[2]](diffhunk://#diff-12a9a4b1453cab2346305cc155ee8710587036918ae5bcb98c912f93361d3262L81-R218) [[3]](diffhunk://#diff-f99a57016f2410875f6d7f44adc976e3085759c213491fe3853102ed70f5e0deL196-R284)
* Updated tests to match the new channel-based API, including new handler tests for echo and heartbeat forwarding, and improved error condition checks. (`pkg/httpresponse/jsonstream_test.go`) [[1]](diffhunk://#diff-f99a57016f2410875f6d7f44adc976e3085759c213491fe3853102ed70f5e0deL80-R98) [[2]](diffhunk://#diff-f99a57016f2410875f6d7f44adc976e3085759c213491fe3853102ed70f5e0deL196-R284)

**Error Response Consistency:**

* Added a `Type` field with value `"error"` to `ErrResponse` for all error responses, updated construction and tests to include this field. (`pkg/httpresponse/error.go`, `pkg/httpresponse/error_test.go`) [[1]](diffhunk://#diff-9e2fc44f075f328c632b636516d3b8398844b015d53a667f4000ea8d87667f01R21) [[2]](diffhunk://#diff-9e2fc44f075f328c632b636516d3b8398844b015d53a667f4000ea8d87667f01R49) [[3]](diffhunk://#diff-c098ffa11a58652478d87798815896ff12f533913c753a8271efd253440646bdR39) [[4]](diffhunk://#diff-c098ffa11a58652478d87798815896ff12f533913c753a8271efd253440646bdR59)

**Content Type Parsing and Handling:**

* Improved `ParseContentType` to default to `"application/octet-stream"` (binary) on empty or invalid headers, and updated `AcceptContentType` and `RequestContentType` to return appropriate defaults instead of errors. Added legacy JSON stream mimetype constant. (`pkg/types/mime.go`, `pkg/types/http.go`, `pkg/types/http_test.go`, `pkg/types/mime_test.go`) [[1]](diffhunk://#diff-14c423f247804371d35343419ccfb57a4955bbc08977848299ec4fc3e3c6b459L35-R46) [[2]](diffhunk://#diff-8c0de387b6f887b5a1238eb2265ef73b82979a8afa47f179165b56455be3b68dL32-R36) [[3]](diffhunk://#diff-31b5dc6ff24b0d432837c686e01bb7d84e798bd418524cefb7326766913415c9L32-R34) [[4]](diffhunk://#diff-a17695bfc813343b803c3f68f453b825358fca0e1dce7751154404de7caf6523L15-R17)

**Middleware and Flushing Improvements:**

* Ensured middleware-wrapped response writers preserve streaming semantics by implementing `Flush` passthrough in the custom response writer. Added test to verify compatibility with the new JSON stream API. (`pkg/otel/responsewriter.go`, `pkg/otel/middleware_test.go`) [[1]](diffhunk://#diff-568dfb5e240df5d86b0e752a091b1976da5d8852f7204cd1ec55c48f13330215R102-R109) [[2]](diffhunk://#diff-82d0ec420d1ffc2c2ce9e1be76223f3c15445eac4307efb43250dcccdea5e93bR147-R160)

**Other Minor Improvements:**

* Cleaned up imports and improved test assertion consistency. (`pkg/types/http.go`, `pkg/otel/middleware_test.go`) [[1]](diffhunk://#diff-8c0de387b6f887b5a1238eb2265ef73b82979a8afa47f179165b56455be3b68dL13-R14) [[2]](diffhunk://#diff-82d0ec420d1ffc2c2ce9e1be76223f3c15445eac4307efb43250dcccdea5e93bR11-R17)

These changes modernize the streaming API, improve error and content type robustness, and ensure better composability with middleware and HTTP handlers.