### PR TITLE
Update UUID in JSON schema

### DIFF
--- a/pkg/jsonschema/jsonschema.go
+++ b/pkg/jsonschema/jsonschema.go
@@ -390,12 +390,24 @@ func applySpecialTypeSchema(s *upstream.Schema, t reflect.Type) bool {
 		resetToScalarStringSchema(s, "byte")
 		return true
 	default:
+		if isUUIDLikeType(t) {
+			resetToScalarStringSchema(s, "uuid")
+			return true
+		}
 		if isJSONBytesType(t) {
 			resetToScalarStringSchema(s, "json")
 			return true
 		}
 		return false
 	}
+}
+
+func isUUIDLikeType(t reflect.Type) bool {
+	return t.Kind() == reflect.Array &&
+		uuidType.Kind() == reflect.Array &&
+		t.Len() == uuidType.Len() &&
+		t.Elem() == uuidType.Elem() &&
+		t.ConvertibleTo(uuidType)
 }
 
 func isJSONBytesType(t reflect.Type) bool {

--- a/pkg/jsonschema/jsonschema_test.go
+++ b/pkg/jsonschema/jsonschema_test.go
@@ -114,6 +114,13 @@ type uuidNativeStruct struct {
 	Name string    `json:"name"`
 }
 
+type namedUUID uuid.UUID
+
+type namedUUIDStruct struct {
+	ID   namedUUID `json:"id"`
+	Name string    `json:"name"`
+}
+
 type uuidRequiredStruct struct {
 	ID   string `json:"id"   format:"uuid" required:""`
 	Name string `json:"name"`
@@ -628,6 +635,23 @@ func TestFor_FormatTag(t *testing.T) {
 	}
 	if got := s.Properties["count"].Format; got != "int32" {
 		t.Errorf("count format: got %q, want %q", got, "int32")
+	}
+}
+
+func TestFor_NamedUUIDType_UsesUUIDStringSchema(t *testing.T) {
+	s, err := For[namedUUIDStruct]()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prop := s.Properties["id"]
+	if prop == nil {
+		t.Fatal("expected property 'id'")
+	}
+	if prop.Type != "string" {
+		t.Errorf("id type: got %q, want %q", prop.Type, "string")
+	}
+	if prop.Format != "uuid" {
+		t.Errorf("id format: got %q, want %q", prop.Format, "uuid")
 	}
 }
 


### PR DESCRIPTION
This pull request improves the handling of UUID-like types in the JSON schema generation logic. It introduces recognition for user-defined types that are structurally identical to `uuid.UUID`, ensuring these types are correctly mapped to the `"string"` type with `"uuid"` format in the generated schema. Additionally, a new test verifies this behavior.

Enhancements to UUID type handling:

* Updated `applySpecialTypeSchema` in `jsonschema.go` to detect and treat user-defined types that are structurally equivalent to `uuid.UUID` as UUIDs in the schema, using the new helper function `isUUIDLikeType`.
* Added the `isUUIDLikeType` helper function to encapsulate the logic for recognizing UUID-like types.

Testing improvements:

* Introduced `namedUUID` and `namedUUIDStruct` types, and added a new test (`TestFor_NamedUUIDType_UsesUUIDStringSchema`) to ensure that fields of user-defined UUID-like types are correctly represented as `"string"` with `"uuid"` format in the generated schema. [[1]](diffhunk://#diff-1ae7413188df684fa0b222abb5b28dc13b4f5bcee9b2d63875953e7c87b420baR117-R123) [[2]](diffhunk://#diff-1ae7413188df684fa0b222abb5b28dc13b4f5bcee9b2d63875953e7c87b420baR641-R657)