### PR TITLE
Fix bugs in API endpoints

### DIFF
--- a/pkg/cmd/global.go
+++ b/pkg/cmd/global.go
@@ -14,6 +14,7 @@ import (
 	kong "github.com/alecthomas/kong"
 	client "github.com/mutablelogic/go-client"
 	server "github.com/mutablelogic/go-server"
+	types "github.com/mutablelogic/go-server/pkg/types"
 	metric "go.opentelemetry.io/otel/metric"
 	trace "go.opentelemetry.io/otel/trace"
 )
@@ -95,7 +96,7 @@ func (g *global) Meter() metric.Meter {
 // ClientEndpoint returns the HTTP endpoint URL and client options derived
 // from the global HTTP flags.
 func (g *global) ClientEndpoint() (string, []client.ClientOpt, error) {
-	scheme := "http"
+	scheme := types.SchemeInsecure
 	host, port, err := net.SplitHostPort(g.HTTP.Addr)
 	if err != nil {
 		return "", nil, err
@@ -107,8 +108,14 @@ func (g *global) ClientEndpoint() (string, []client.ClientOpt, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	if portn == 443 {
-		scheme = "https"
+	hostaddr := net.JoinHostPort(host, strconv.FormatUint(portn, 10))
+	switch portn {
+	case 80:
+		scheme = types.SchemeInsecure
+		hostaddr = host
+	case 443:
+		scheme = types.SchemeSecure
+		hostaddr = host
 	}
 	opts := []client.ClientOpt{}
 	if g.Debug || g.Verbose {
@@ -120,7 +127,7 @@ func (g *global) ClientEndpoint() (string, []client.ClientOpt, error) {
 	if g.HTTP.Timeout > 0 {
 		opts = append(opts, client.OptTimeout(g.HTTP.Timeout))
 	}
-	return fmt.Sprintf("%s://%s%s", scheme, net.JoinHostPort(host, strconv.FormatUint(portn, 10)), g.HTTP.Prefix), opts, nil
+	return fmt.Sprintf("%s://%s%s", scheme, hostaddr, g.HTTP.Prefix), opts, nil
 }
 
 func (g *global) URL() *url.URL {

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -16,8 +16,8 @@ import (
 	errgroup "golang.org/x/sync/errgroup"
 )
 
-// RegisterFunc is called after the router is created but before the server
-// starts listening. Use it to add routes and wire up handlers.
+// RegisterFunc is called after the server URL has been resolved but before the
+// server starts serving requests. Use it to add routes and wire up handlers.
 type RegisterFunc func(*httprouter.Router) error
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -87,11 +87,19 @@ func (s *RunServer) Run(ctx server.Cmd) error {
 		tlsCfg = &tls.Config{ServerName: s.TLS.ServerName}
 	}
 
-	// Create a new server and start listening. The server will run until the context is cancelled.
+	// Create a new server. The listener is bound before registration so callbacks
+	// can rely on the final advertised URL, including :0 port allocation.
 	srv, err := httpserver.New(ctx.HTTPAddr(), tlsCfg, serverOpts...)
 	if err != nil {
 		return fmt.Errorf("httpserver: %w", err)
-	} else if url := srv.URL(); url != nil {
+	}
+
+	// Bind to the server's address to ensure the advertised URL is final before
+	// route registration runs.
+	if err := srv.Listen(); err != nil {
+		return err
+	}
+	if url := srv.URL(); url != nil {
 		url.Path = types.NormalisePath(ctx.HTTPPrefix())
 		ctx.(*global).url = url
 	}
@@ -124,11 +132,6 @@ func (s *RunServer) Run(ctx server.Cmd) error {
 	// Always register a catch-all 404 handler at the prefix root (e.g. "/api")
 	if err := router.RegisterCatchAll(ctx.HTTPPrefix(), false); err != nil {
 		return fmt.Errorf("catchall: %w", err)
-	}
-
-	// Bind to the server's address to ensure it's available
-	if err := srv.Listen(); err != nil {
-		return err
 	}
 
 	// Set the server URL in the OpenAPI spec now that the bound address is known.

--- a/pkg/cmd/server_test.go
+++ b/pkg/cmd/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -126,5 +127,96 @@ func Test_ClientEndpoint_Verbose(t *testing.T) {
 	}
 	if len(opts) == 0 {
 		t.Error("expected opts when Verbose=true, got none")
+	}
+}
+
+func Test_RunServer_AdvertisedURL(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g := &global{
+		ctx:    ctx,
+		logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	}
+	g.HTTP.Addr = ":0"
+	g.HTTP.Prefix = "/api"
+
+	s := &RunServer{}
+	var registerURL string
+	s.Register(func(_ *httprouter.Router) error {
+		if url := g.URL(); url != nil {
+			registerURL = url.String()
+		}
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Run(g)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	if registerURL == "" {
+		t.Fatal("expected URL to be available during route registration")
+	}
+	if !strings.HasPrefix(registerURL, "http://localhost:") {
+		t.Fatalf("register URL = %q, want localhost prefix", registerURL)
+	}
+	if strings.Contains(registerURL, ":0/") {
+		t.Fatalf("register URL = %q, want bound port instead of :0", registerURL)
+	}
+
+	if url := g.URL(); url == nil {
+		t.Fatal("expected URL after listen")
+	} else if strings.Contains(url.String(), ":0/") {
+		t.Fatalf("final URL = %q, want bound port", url.String())
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Test_RunServer_AdvertisedURL_TLSName(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g := &global{
+		ctx:    ctx,
+		logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	}
+	g.HTTP.Addr = ":0"
+	g.HTTP.Prefix = "/api"
+
+	s := &RunServer{}
+	s.TLS.ServerName = "auth.example.com"
+	var registerURL string
+	s.Register(func(_ *httprouter.Router) error {
+		if url := g.URL(); url != nil {
+			registerURL = url.String()
+		}
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Run(g)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	if registerURL != "https://auth.example.com/api" {
+		t.Fatalf("register URL = %q, want %q", registerURL, "https://auth.example.com/api")
+	}
+
+	if url := g.URL(); url == nil {
+		t.Fatal("expected URL after listen")
+	} else if got := url.String(); got != "https://auth.example.com/api" {
+		t.Fatalf("final URL = %q, want %q", got, "https://auth.example.com/api")
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strings"
 	"sync"
@@ -129,7 +130,7 @@ func (server *server) URL() *url.URL {
 	var url url.URL
 	url.Scheme = defaultListenPortHttp
 	url.Path = "/"
-	url.Host = server.Addr()
+	url.Host = normalizeURLHost(server.Addr())
 	if server.serverName != "" {
 		url.Scheme = defaultListenPortHttps
 		url.Host = server.serverName
@@ -202,4 +203,24 @@ func (server *server) shutdown() error {
 	} else {
 		return err
 	}
+}
+
+func normalizeURLHost(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	if host == "" || isUnspecifiedHost(host) {
+		host = defaultListenHost
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func isUnspecifiedHost(host string) bool {
+	host = strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(host), "]"), "[")
+	if host == "" {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.IsUnspecified()
 }

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -361,6 +361,29 @@ func Test_Listen_002(t *testing.T) {
 	assert.Equal("localhost:9999", s.Addr())
 }
 
+func Test_URL_001(t *testing.T) {
+	assert := assert.New(t)
+
+	// Empty listen host should advertise localhost rather than a bare :port URL.
+	s, err := httpserver.New(":8084", nil)
+	assert.NoError(err)
+	if assert.NotNil(s.URL()) {
+		assert.Equal("http://localhost:8084/", s.URL().String())
+	}
+}
+
+func Test_URL_002(t *testing.T) {
+	assert := assert.New(t)
+
+	// Wildcard listener addresses should advertise localhost for local development.
+	s, err := httpserver.New(":0", nil)
+	assert.NoError(err)
+	assert.NoError(s.Listen())
+	if assert.NotNil(s.URL()) {
+		assert.Contains(s.URL().String(), "http://localhost:")
+	}
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // TESTS - RUN
 


### PR DESCRIPTION
This pull request improves how the server determines and advertises its URL, especially when binding to wildcard or unspecified addresses (like `:0` or `0.0.0.0`). It ensures that the advertised URLs are user-friendly (e.g., using `localhost` instead of bare or unspecified hosts), and that the final URL is available during route registration. Additionally, it updates and expands tests to verify this behavior.

**Server URL advertisement and normalization:**

* The server now normalizes advertised URLs to use `localhost` when binding to unspecified or wildcard addresses, making development and testing easier and more predictable. This is handled by the new `normalizeURLHost` and `isUnspecifiedHost` functions in `httpserver.go`. [[1]](diffhunk://#diff-968a7bae566c0feb5da17bf686446e84ebeb191584c0aff4ab4ce436f61ae40aL132-R133) [[2]](diffhunk://#diff-968a7bae566c0feb5da17bf686446e84ebeb191584c0aff4ab4ce436f61ae40aR207-R226)
* The server binds its listener before running route registration callbacks, ensuring that the final advertised URL (including the actual port) is available during registration. [[1]](diffhunk://#diff-f537cf1d2759ca20b0e0667620e9aff9245f5b0512d1bd9c7b77c7edb83edb0cL90-R102) [[2]](diffhunk://#diff-f537cf1d2759ca20b0e0667620e9aff9245f5b0512d1bd9c7b77c7edb83edb0cL129-L133)

**Client endpoint and scheme handling:**

* The logic for determining the URL scheme and host/port in `global.go` has been improved to use symbolic constants and to avoid including the port in the host for standard ports (80/443). [[1]](diffhunk://#diff-26f9c13b7c017851b563904dce4099b7a7f03be73372e8ef8bd4ebbd30ba3783R17) [[2]](diffhunk://#diff-26f9c13b7c017851b563904dce4099b7a7f03be73372e8ef8bd4ebbd30ba3783L98-R99) [[3]](diffhunk://#diff-26f9c13b7c017851b563904dce4099b7a7f03be73372e8ef8bd4ebbd30ba3783L110-R118) [[4]](diffhunk://#diff-26f9c13b7c017851b563904dce4099b7a7f03be73372e8ef8bd4ebbd30ba3783L123-R130)

**Testing improvements:**

* Added and updated tests in `server_test.go` and `httpserver_test.go` to verify that the advertised URLs are correct (e.g., using `localhost` and the correct scheme/port), and that the URL is available during route registration. [[1]](diffhunk://#diff-71a9da1ead01130107a0548663ea9848873eeae9d79413e77626c337e67ed69bR132-R222) [[2]](diffhunk://#diff-420fd3735735b80c05321dccd1b7f0e754ebae09c12fda0d90276c35488767b9R364-R386)

**Documentation and minor refactoring:**

* Updated comments and documentation to clarify the server lifecycle and the timing of route registration relative to listener binding.

These changes ensure more reliable and user-friendly server URLs, especially in development environments.