### PR TITLE
Fix CORS configuration for serving resources

### DIFF
--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -114,6 +114,7 @@ func (s *RunServer) Run(ctx server.Cmd) error {
 	if err != nil {
 		return fmt.Errorf("router: %w", err)
 	}
+	srv.SetHandler(router)
 
 	// Register routes
 	for _, fn := range s.register {

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -100,6 +100,17 @@ func (server *server) Router() *http.ServeMux {
 	return server.mux
 }
 
+// SetHandler replaces the server's active HTTP handler. This is used when a
+// higher-level router wraps the underlying ServeMux with middleware such as
+// CORS, CSRF protection, tracing, or authentication.
+func (server *server) SetHandler(handler http.Handler) {
+	if handler == nil {
+		server.http.Handler = server.mux
+		return
+	}
+	server.http.Handler = handler
+}
+
 // Addr returns the listen address. After [Listen] has been called this
 // returns the actual bound address (which may differ from the configured
 // address when an ephemeral port is used).

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -203,6 +203,40 @@ func Test_Options_004(t *testing.T) {
 	assert.NotNil(s)
 }
 
+func Test_Server_UsesCustomHandler(t *testing.T) {
+	assert := assert.New(t)
+
+	s, err := httpserver.New(":0", nil)
+	if !assert.NoError(err) {
+		return
+	}
+
+	s.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if !assert.NoError(s.Listen()) {
+		return
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Run(ctx)
+	}()
+
+	resp, err := http.Get(s.URL().String())
+	if assert.NoError(err) {
+		defer resp.Body.Close()
+		assert.Equal(http.StatusAccepted, resp.StatusCode)
+	}
+
+	cancel()
+	assert.NoError(<-done)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // TESTS - TLS CONFIG
 


### PR DESCRIPTION
This pull request introduces a new mechanism to allow replacing the HTTP handler in the server, enabling more flexible middleware integration. It also adds a corresponding unit test to ensure the new functionality works as expected.

**HTTP handler customization:**

* Added a `SetHandler` method to the `server` struct in `pkg/httpserver/httpserver.go`, allowing the active HTTP handler to be replaced at runtime. This is useful for wrapping the server's router with middleware such as CORS, CSRF protection, or authentication.
* Updated `RunServer.Run` in `pkg/cmd/server.go` to use the new `SetHandler` method, ensuring the router is set as the handler before registering routes.

**Testing:**

* Added `Test_Server_UsesCustomHandler` in `pkg/httpserver/httpserver_test.go` to verify that a custom handler can be set and used by the server, checking that the expected HTTP status code is returned.