### PR TITLE
Add child context for global variables

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -79,6 +79,9 @@ type Cmd interface {
 
 	// HTTPTimeout returns the HTTP read/write timeout.
 	HTTPTimeout() time.Duration
+
+	// WithContext returns a copy of the Cmd with the provided context.
+	WithContext(context.Context) Cmd
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/cmd/global.go
+++ b/pkg/cmd/global.go
@@ -59,6 +59,11 @@ type global struct {
 	defaults
 }
 
+type child struct {
+	server.Cmd
+	ctx context.Context
+}
+
 // Ensure *globals implements server.Cmd
 var _ server.Cmd = (*global)(nil)
 
@@ -79,6 +84,10 @@ func (g *global) Version() string {
 
 func (g *global) Context() context.Context {
 	return g.ctx
+}
+
+func (c *child) Context() context.Context {
+	return c.ctx
 }
 
 func (g *global) Logger() *slog.Logger {
@@ -165,4 +174,12 @@ func (g *global) HTTPPrefix() string {
 
 func (g *global) HTTPTimeout() time.Duration {
 	return g.HTTP.Timeout
+}
+
+// WithContext returns a copy of the Cmd with the provided context.
+func (g *global) WithContext(ctx context.Context) server.Cmd {
+	return types.Ptr(child{
+		Cmd: g,
+		ctx: ctx,
+	})
 }


### PR DESCRIPTION
This pull request introduces support for context propagation in the `Cmd` interface and its implementations. The main changes include adding a `WithContext` method to the `Cmd` interface, implementing a new `child` struct to handle context, and updating the relevant methods to support this functionality.

**Context propagation support:**

* Added the `WithContext(context.Context) Cmd` method to the `Cmd` interface in `interfaces.go` to allow creating copies of `Cmd` with a new context.
* Added a new `child` struct in `pkg/cmd/global.go` to wrap `Cmd` with a specific context, and implemented its `Context()` method. [[1]](diffhunk://#diff-26f9c13b7c017851b563904dce4099b7a7f03be73372e8ef8bd4ebbd30ba3783R62-R66) [[2]](diffhunk://#diff-26f9c13b7c017851b563904dce4099b7a7f03be73372e8ef8bd4ebbd30ba3783R89-R92)
* Implemented the `WithContext` method for the `global` struct, returning a new `child` instance with the provided context.