### PR TITLE
Added Append method for tables

### DIFF
--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -24,6 +24,7 @@ type TableRow interface {
 type table[T TableRow] struct {
 	table  *lgtable.Table
 	widths []int
+	rows   []T
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -63,25 +64,39 @@ func TableFor[T TableRow](options ...Opt) *table[T] {
 ///////////////////////////////////////////////////////////////////////////////
 // RENDER
 
+func (t *table[T]) Append(rows ...T) *table[T] {
+	if len(rows) > 0 {
+		t.rows = append(t.rows, rows...)
+	}
+	return t
+}
+
 func (t *table[T]) Write(w io.Writer, rows ...T) (int, error) {
+	if len(rows) > 0 {
+		t.Append(rows...)
+	}
+
 	t.table.ClearRows()
-	if len(rows) == 0 {
+	if len(t.rows) == 0 {
 		return io.WriteString(w, "")
 	}
 
-	headers := rows[0].Header()
+	headers := t.rows[0].Header()
 	t.widths = make([]int, len(headers))
 	for i := range headers {
-		t.widths[i] = rows[0].Width(i)
+		t.widths[i] = t.rows[0].Width(i)
 	}
 	t.table.Headers(headers...)
-	for _, row := range rows {
+	for _, row := range t.rows {
 		cells := make([]string, len(headers))
 		for i := range headers {
 			cells[i] = row.Cell(i)
 		}
 		t.table.Row(cells...)
 	}
+	defer func() {
+		t.rows = nil
+	}()
 
 	return io.WriteString(w, fmt.Sprintln(t.table.Render()))
 }

--- a/pkg/tui/table_test.go
+++ b/pkg/tui/table_test.go
@@ -37,9 +37,28 @@ func TestTableWriteEmpty(t *testing.T) {
 func TestTableWriteEndsWithNewline(t *testing.T) {
 	var buffer bytes.Buffer
 
-	n, err := TableFor[testRow]().Write(&buffer, testRow{value: "alpha"})
+	table := TableFor[testRow]()
+	table.Append(testRow{value: "alpha"})
+	n, err := table.Write(&buffer)
 	require.NoError(t, err)
 	assert.Equal(t, len(buffer.String()), n)
 	assert.True(t, strings.HasSuffix(buffer.String(), "\n"))
 	assert.Contains(t, buffer.String(), "alpha")
+}
+
+func TestTableWriteFlushesBufferedRows(t *testing.T) {
+	var buffer bytes.Buffer
+
+	table := TableFor[testRow]()
+	table.Append(testRow{value: "alpha"}, testRow{value: "beta"})
+
+	_, err := table.Write(&buffer)
+	require.NoError(t, err)
+	assert.Contains(t, buffer.String(), "alpha")
+	assert.Contains(t, buffer.String(), "beta")
+
+	buffer.Reset()
+	_, err = table.Write(&buffer)
+	require.NoError(t, err)
+	assert.Equal(t, "", buffer.String())
 }


### PR DESCRIPTION
This pull request enhances the `table` component in the TUI package to support buffered row management, allowing rows to be appended and automatically flushed on write. It also introduces new tests to ensure the correct behavior of row buffering and flushing.

**Enhancements to table row management:**

* Added a `rows` field to the `table` struct to buffer appended rows before rendering.
* Implemented an `Append` method on `table` to add rows to the buffer.
* Modified the `Write` method to use buffered rows, flush them after writing, and support writing without passing rows explicitly.

**Testing improvements:**

* Updated existing tests to use the new `Append` method and verify newline handling.
* Added a new test `TestTableWriteFlushesBufferedRows` to confirm that buffered rows are correctly flushed after writing.