### PR TITLE
JSON Schema changes

### DIFF
--- a/pkg/jsonschema/jsonschema.go
+++ b/pkg/jsonschema/jsonschema.go
@@ -157,6 +157,22 @@ func For[T any]() (*Schema, error) {
 		if err := enrichSchema(s, t); err != nil {
 			return nil, err
 		}
+	} else if ft.Kind() == reflect.Slice || ft.Kind() == reflect.Array {
+		// T itself is a slice/array (e.g. a named "type FooList []Foo"), not a
+		// field of some enriched struct - enrichArrayItems is otherwise only
+		// reached via enrichSchema for slice-typed fields, so without this
+		// branch a top-level slice type's element schema never gets its
+		// struct tag annotations (help, example, etc.) applied.
+		if err := enrichArrayItems(s, ft); err != nil {
+			return nil, err
+		}
+
+		// As with slice-typed fields (see enrichSchema), the upstream library
+		// adds "null" because Go slices have a nil zero value, but a JSON API
+		// returns an absent list as [], never null - and a schema advertising
+		// "null" as a possibility leads tooling (e.g. example generators) to
+		// treat null as a valid, even preferred, response shape.
+		removeNullType(s)
 	}
 	res := &Schema{*s, nil}
 	resolved, err := res.Resolve(nil)
@@ -276,10 +292,7 @@ func enrichSchema(s *upstream.Schema, t reflect.Type) error {
 				}
 			}
 			if isRequired {
-				prop.Types = removeString(prop.Types, "null")
-				if prop.Type == "null" {
-					prop.Type = ""
-				}
+				removeNullType(prop)
 			}
 		}
 
@@ -287,10 +300,7 @@ func enrichSchema(s *upstream.Schema, t reflect.Type) error {
 		// because Go slices have a nil zero value, but in JSON APIs an absent
 		// slice is omitted or [], never null.
 		if ft.Kind() == reflect.Slice {
-			prop.Types = removeString(prop.Types, "null")
-			if prop.Type == "null" {
-				prop.Type = ""
-			}
+			removeNullType(prop)
 		}
 
 		if v := field.Tag.Get("min"); v != "" {
@@ -337,8 +347,11 @@ func enrichSchema(s *upstream.Schema, t reflect.Type) error {
 }
 
 func enrichArrayItems(prop *upstream.Schema, t reflect.Type) error {
-	elem := t.Elem()
+	origElem := t.Elem()
+	elem := origElem
+	isPointer := false
 	for elem.Kind() == reflect.Pointer {
+		isPointer = true
 		elem = elem.Elem()
 	}
 
@@ -346,9 +359,17 @@ func enrichArrayItems(prop *upstream.Schema, t reflect.Type) error {
 		return nil
 	}
 
+	// A slice of pointers (e.g. []*Format) gets "null" added to each item's
+	// schema because a *Format can be nil - but a JSON array representing a
+	// dynamically-sized list never actually contains null placeholders for
+	// its elements, so left in, it leads tooling (e.g. example generators)
+	// to render a null element instead of a real one.
 	if prop.Items != nil {
 		if err := enrichSchema(prop.Items, elem); err != nil {
 			return err
+		}
+		if isPointer {
+			removeNullType(prop.Items)
 		}
 	}
 	for _, item := range prop.ItemsArray {
@@ -357,6 +378,9 @@ func enrichArrayItems(prop *upstream.Schema, t reflect.Type) error {
 		}
 		if err := enrichSchema(item, elem); err != nil {
 			return err
+		}
+		if isPointer {
+			removeNullType(item)
 		}
 	}
 
@@ -543,6 +567,17 @@ func appendUnique(ss []string, s string) []string {
 		}
 	}
 	return append(ss, s)
+}
+
+// removeNullType strips "null" from a schema's Types (and clears Type if it
+// was the sole "null"), for cases where the upstream library allows null
+// (typically because the Go zero value - a nil slice or pointer - permits
+// it) but the JSON API contract does not.
+func removeNullType(s *upstream.Schema) {
+	s.Types = removeString(s.Types, "null")
+	if s.Type == "null" {
+		s.Type = ""
+	}
 }
 
 func removeString(ss []string, s string) []string {

--- a/pkg/jsonschema/jsonschema_test.go
+++ b/pkg/jsonschema/jsonschema_test.go
@@ -2020,3 +2020,88 @@ func TestFor_SliceField_NoNull(t *testing.T) {
 		}
 	}
 }
+
+// Regression test: For[T]() only enriched struct-typed fields nested inside
+// an enriched parent struct - a slice/array passed directly as the top-level
+// T (e.g. a named "type FooList []Foo" response type, as opposed to a slice
+// field of some other struct) skipped enrichment entirely, so struct tag
+// annotations (help, example, required, ...) never reached its element
+// schema's properties.
+func TestFor_SliceTopLevel_ElementEnriched(t *testing.T) {
+	type namedSlice []exampleStruct
+
+	s, err := For[namedSlice]()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Items == nil {
+		t.Fatal("expected Items schema for top-level slice type")
+	}
+	prop := s.Items.Properties["name"]
+	if prop == nil {
+		t.Fatal("expected Items property 'name'")
+	}
+	if len(prop.Examples) != 1 || prop.Examples[0] != "alice" {
+		t.Errorf("Items.Properties[name].Examples = %v, want [\"alice\"]", prop.Examples)
+	}
+}
+
+// Regression test: as with slice-typed fields, a top-level named slice type
+// must not advertise "null" as a valid type - a Go slice's nil zero value
+// isn't a meaningful API response shape, and leaving "null" in leads tooling
+// (e.g. example generators) to treat null as a valid response.
+func TestFor_SliceTopLevel_NoNull(t *testing.T) {
+	type namedSlice []exampleStruct
+
+	s, err := For[namedSlice]()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, typ := range s.Types {
+		if typ == "null" {
+			t.Errorf("Types contains \"null\", want no null for a top-level slice type: %v", s.Types)
+		}
+	}
+	if s.Type == "null" {
+		t.Errorf("Type is \"null\", want \"array\"")
+	}
+}
+
+// Regression test: a slice of pointers-to-struct (e.g. "Body []*Format" in
+// a paginated list response) had each item's schema advertise "null" as a
+// valid element, because *Format is nilable - even though a JSON array
+// representing a dynamically-sized list never actually contains null
+// placeholders for its elements. Left in, this led example generators to
+// render a null element instead of a real one.
+func TestFor_SliceOfPointerField_ItemsNoNull(t *testing.T) {
+	type S struct {
+		Body []*exampleStruct `json:"body"`
+	}
+	s, err := For[S]()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prop := s.Properties["body"]
+	if prop == nil {
+		t.Fatal("expected property 'body'")
+	}
+	if prop.Items == nil {
+		t.Fatal("expected Items schema for 'body'")
+	}
+	for _, typ := range prop.Items.Types {
+		if typ == "null" {
+			t.Errorf("body.Items.Types contains \"null\", want no null for slice-of-pointer elements: %v", prop.Items.Types)
+		}
+	}
+	if prop.Items.Type == "null" {
+		t.Errorf("body.Items.Type is \"null\", want \"object\"")
+	}
+	// The element schema should still be enriched (e.g. example tags reach it).
+	nameProp := prop.Items.Properties["name"]
+	if nameProp == nil {
+		t.Fatal("expected Items property 'name'")
+	}
+	if len(nameProp.Examples) != 1 || nameProp.Examples[0] != "alice" {
+		t.Errorf("body.Items.Properties[name].Examples = %v, want [\"alice\"]", nameProp.Examples)
+	}
+}


### PR DESCRIPTION
This pull request improves the handling of JSON schema generation for slice and array types, ensuring that struct tag annotations are properly applied to element schemas and that "null" is not incorrectly advertised as a valid type in generated schemas. This addresses several issues where the previous implementation could lead to inaccurate or misleading schema definitions, especially for top-level slice types and slices of pointers.

### Schema enrichment and "null" type handling improvements

* Ensured that when the top-level type is a slice or array (e.g., a named slice type), its element schema is properly enriched with struct tag annotations, such as `help`, `example`, and `required` (`jsonschema.go` For[T any](), enrichArrayItems) [[1]](diffhunk://#diff-2bb045ae3b2bcba7775b94ff9aa8df18e6d0ce7eea47154e5ee9fbf6702f22deR160-R175) [[2]](diffhunk://#diff-2bb045ae3b2bcba7775b94ff9aa8df18e6d0ce7eea47154e5ee9fbf6702f22deL340-R373).
* Refactored the removal of "null" from schema types into a helper function `removeNullType`, and applied it consistently to both slice-typed fields and top-level slice/array types, preventing tools from treating `null` as a valid or preferred response shape (`jsonschema.go` removeNullType, enrichSchema, enrichArrayItems) [[1]](diffhunk://#diff-2bb045ae3b2bcba7775b94ff9aa8df18e6d0ce7eea47154e5ee9fbf6702f22deL279-R303) [[2]](diffhunk://#diff-2bb045ae3b2bcba7775b94ff9aa8df18e6d0ce7eea47154e5ee9fbf6702f22deL340-R373) [[3]](diffhunk://#diff-2bb045ae3b2bcba7775b94ff9aa8df18e6d0ce7eea47154e5ee9fbf6702f22deR382-R384) [[4]](diffhunk://#diff-2bb045ae3b2bcba7775b94ff9aa8df18e6d0ce7eea47154e5ee9fbf6702f22deR572-R582).

### Regression test coverage

* Added regression tests to verify that:
  - Top-level slice types have their element schemas enriched with struct tag annotations (`TestFor_SliceTopLevel_ElementEnriched`).
  - Top-level slice types do not advertise "null" as a valid type (`TestFor_SliceTopLevel_NoNull`).
  - Slices of pointer-to-struct fields do not allow "null" as a valid element in their schema, and their element schemas are properly enriched (`TestFor_SliceOfPointerField_ItemsNoNull`).

These changes ensure that the generated JSON schemas more accurately reflect the actual API contracts and improve compatibility with downstream tooling.